### PR TITLE
Fix for OS X to use Framework version of OpenAL

### DIFF
--- a/al/bindings.lisp
+++ b/al/bindings.lisp
@@ -2,6 +2,7 @@
 
 (define-foreign-library al
   (:windows "OpenAL32.dll" :calling-convention :stdcall)
+  (:darwin (:or (:framework "openal") (:default "libopenal")))
   (:unix (:or "libopenal.so" "libopenal.so.1"))
   (t (:default "libopenal")))
 (use-foreign-library al)


### PR DESCRIPTION
Fixed foreign library definition to use Frameworks or platform defaults on OS X (Darwin).
