### PR TITLE
Minor fixes

### DIFF
--- a/al/al.lisp
+++ b/al/al.lisp
@@ -58,11 +58,9 @@
 (defun get-listener (param)
   (ecase param
     ((:gain)
-     (let* ((ptr (cffi:foreign-alloc :float))
-            (val (progn
-                   (%al:get-listener-f param ptr)
-                   (cffi:mem-ref ptr :float))))
-       val))
+     (cffi:with-foreign-object (ptr :float)
+       (%al:get-listener-f param ptr)
+       (cffi:mem-ref ptr :float)))
     ((:orientation)
      (cffi:with-foreign-object (listener-array :float 6)
        (%al:get-listener-fv param listener-array)
@@ -116,35 +114,26 @@
     ((:gain :pitch :min-gain :max-gain :reference-distance
             :sec-offset :rolloff-factor :max-distance :cone-inner-angle :cone-outer-angle :cone-outer-gain
             :sample-offset :byte-offset)
-     (let* ((ptr (cffi:foreign-alloc :float))
-            (val (progn
-                   (%al:get-source-f sid param ptr)
-                   (cffi:mem-ref ptr :float))))
-       val))
+     (cffi:with-foreign-object (ptr :float)
+       (%al:get-source-f sid param ptr)
+       (cffi:mem-ref ptr :float)))
     ((:looping :source-relative)
-     (let* ((ptr (cffi:foreign-alloc :int))
-            (val (progn
-                   (%al:get-source-i sid param ptr)
-                   (cffi:mem-ref ptr :int))))
-       (if (> val 0)
-           t nil)))
+     (cffi:with-foreign-object (ptr :int)
+       (%al:get-source-i sid param ptr)
+       (cffi:mem-ref ptr :boolean)))
     ((:source-type :buffer :buffers-queued :buffers-processed)
-     (let* ((ptr (cffi:foreign-alloc :int))
-            (val (progn
-                   (%al:get-source-i sid param ptr)
-                   (cffi:mem-ref ptr :int))))
-       val))
+     (cffi:with-foreign-object (ptr :int)
+       (%al:get-source-i sid param ptr)
+       (cffi:mem-ref ptr :int)))
     (:source-state
-     (let* ((ptr (cffi:foreign-alloc :int))
-            (val (progn
-                   (%al:get-source-i sid param ptr)
-                   (cffi:mem-ref ptr :int))))
-       (cffi:foreign-enum-keyword '%al:enum val)))
+     (cffi:with-foreign-object (ptr :int)
+       (%al:get-source-i sid param ptr)
+       (cffi:foreign-enum-keyword '%al:enum (cffi:mem-ref ptr :int))))
     ((:position :velocity :direction)
      (cffi:with-foreign-object (source-array :float 3)
        (%al:get-source-fv sid param source-array)
        (loop for i below 3
-          collect (cffi:mem-aref source-array :float i))))))
+	     collect (cffi:mem-aref source-array :float i))))))
 
 ;; Playback
 (defun source-play (sid)
@@ -204,11 +193,9 @@
   (%al:buffer-data bid format data size freq))
 
 (defun get-buffer (bid param)
-  (let* ((ptr (cffi:foreign-alloc :int))
-         (val (progn
-                (%al:get-buffer-i bid param ptr)
-                (cffi:mem-ref ptr :int))))
-    val))
+  (cffi:with-foreign-object (ptr :int)
+    (%al:get-buffer-i bid param ptr)
+    (cffi:mem-ref ptr :int)))
 
 ;;;
 ;;; Global parameters

--- a/al/bindings.lisp
+++ b/al/bindings.lisp
@@ -265,7 +265,7 @@
 (defcfun ("alGetBuffer3f" get-buffer-3f) :void
   (bid :uint) (param enum) (value1 :pointer) (value2 :pointer) (value3 :pointer))
 (defcfun ("alGetBufferfv" get-buffer-fv) :void (bid :uint) (param enum) (values :pointer))
-(defcfun ("alGetBufferi" get-buffer-i) :void (bid :uint) (param enum) (value :pointer))
+(defcfun ("alGetBufferi" get-buffer-i) :void (bid :uint) (param format) (value :pointer))
 (defcfun ("alGetBuffer3i" get-buffer-3i) :void 
   (bid :uint) (param enum) (value1 :pointer) (value2 :pointer) (value3 :pointer))
 (defcfun ("alGetBufferiv" get-buffer-iv) :void (bid :uint) (param enum) (values :pointer))

--- a/alut/alut.lisp
+++ b/alut/alut.lisp
@@ -44,65 +44,67 @@
 ;;; Loading memory
 ;;;
 (defun load-memory-from-file (filename)
-  (let ((format (cffi:foreign-alloc '%al:enum))
-        (size (cffi:foreign-alloc :int))
-        (frequency (cffi:foreign-alloc '%al:ensure-float)))
+  (cffi:with-foreign-objects ((format '%al:enum)
+			      (size :int)
+			      (frequency '%al:ensure-float))
     (values-list
      (cons
       (%alut:load-memory-from-file filename format size frequency)
       (handler-case
-          (list (cffi:mem-ref format '%al:enum)
-                (cffi:mem-ref size :int)
-                (cffi:mem-ref frequency '%al:ensure-float))
-        (error ()
-          (error "There was an error loading ~A" filename)))))))
+	  (list (cffi:mem-ref format '%al:enum)
+		(cffi:mem-ref size :int)
+		(cffi:mem-ref frequency '%al:ensure-float))
+	(error ()
+	  (error "There was an error loading ~A" filename)))))))
 
 (defun load-memory-from-file-image (data)
-  (let ((length (length data))
-        (format (cffi:foreign-alloc '%al:enum))
-        (size (cffi:foreign-alloc :int))
-        (frequency (cffi:foreign-alloc '%al::ensure-float)))
-    (cffi:with-foreign-object (data-array :int length)
+  (let ((length (length data)))
+    (cffi:with-foreign-objects ((format '%al:enum)
+				(size :int)
+				(frequency '%al:ensure-float)
+				(data-array :int length))
       (loop for i below length
-         do (setf (cffi:mem-aref data-array :int i)
-                  (elt data i)))
+	    do (setf (cffi:mem-aref data-array :int i)
+		     (elt data i)))
       (values-list
        (cons
-        (%alut:load-memory-from-file-image data-array length format size frequency)
-        (handler-case
-            (list (cffi:mem-ref format '%al:enum)
-                  (cffi:mem-ref size :int)
-                  (cffi:mem-ref frequency '%al::ensure-float))
-          (error ()
-            (error "There was an error loading data"))))))))
+	(%alut:load-memory-from-file-image data-array length format size
+					   frequency)
+	(handler-case
+	    (list (cffi:mem-ref format '%al:enum)
+		  (cffi:mem-ref size :int)
+		  (cffi:mem-ref frequency '%al::ensure-float))
+	  (error ()
+	    (error "There was an error loading data"))))))))
 
 (defun load-memory-hello-world ()
-  (let ((format (cffi:foreign-alloc '%al:enum))
-        (size (cffi:foreign-alloc :int))
-        (frequency (cffi:foreign-alloc '%al::ensure-float)))
+  (cffi:with-foreign-objects ((format '%al:enum)
+			      (size :int)
+			      (frequency '%al:ensure-float))
     (values-list
      (cons
       (%alut:load-memory-hello-world format size frequency)
       (handler-case
-          (list (cffi:mem-ref format '%al:enum)
-                (cffi:mem-ref size :int)
-                (cffi:mem-ref frequency '%al::ensure-float))
-        (error ()
-          (error "There was an error loading memory!")))))))
+	  (list (cffi:mem-ref format '%al:enum)
+		(cffi:mem-ref size :int)
+		(cffi:mem-ref frequency '%al::ensure-float))
+	(error ()
+	  (error "There was an error loading memory!")))))))
 
 (defun load-memory-waveform (waveshape frequency phase duration)
-  (let ((format (cffi:foreign-alloc '%al:enum))
-        (size (cffi:foreign-alloc :int))
-        (freq (cffi:foreign-alloc '%al::ensure-float)))
+  (cffi:with-foreign-objects ((format '%al:enum)
+			      (size :int)
+			      (freq '%al:ensure-float))
     (values-list
      (cons
-      (%alut:load-memory-waveform waveshape frequency phase duration format size freq)
+      (%alut:load-memory-waveform waveshape frequency phase duration format
+				  size freq)
       (handler-case
-          (list (cffi:mem-ref format '%al:enum)
-                (cffi:mem-ref size :int)
-                (cffi:mem-ref freq '%al::ensure-float))
-        (error ()
-          (error "There was an error loading this waveform")))))))
+	  (list (cffi:mem-ref format '%al:enum)
+		(cffi:mem-ref size :int)
+		(cffi:mem-ref freq '%al::ensure-float))
+	(error ()
+	  (error "There was an error loading this waveform")))))))
 
 ;;;
 ;;; Misc


### PR DESCRIPTION
Fix: get-buffer-i should take format enum
Fix: Memory leaks; removed all cffi:foreign-alloc,
     prefering cffi:with-foreign-object(s).
