### PR TITLE
Fix broken ALUT:WITH-INIT definition

### DIFF
--- a/alut/alut.lisp
+++ b/alut/alut.lisp
@@ -126,7 +126,7 @@
 
 (defmacro with-init (&body body)
   `(unwind-protect
-        (init)
-     (progn
-       ,@body)
+        (progn
+          (init)
+          ,@body)
      (alut:exit)))


### PR DESCRIPTION
There was a previous PR with a similar fix at #7, but it seems that one got its history mangled and eventually got closed.