### PR TITLE
Fix error handling

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -21,6 +21,64 @@ order to use cl-alut (such as freealut).
 cl-openal should run on all major platforms, including Linux, the BSDs, OSX, and Windows. It should
 be usable by any Common Lisp implementation supported by CFFI.
 
+Error handling
+--------------
+
+**BREAKING CHANGE NOTICE:** The new error handling API represents a breaking change. It introduces
+`*PROPAGATE-ERRORS*` with the default value of `T`, which means that OpenAL operations which would
+previously fail silently will now signal `AL-ERROR` in case of an error. This is a better default,
+but will break well-written code using the old API that expects to do its own error checking using
+`GET-ERROR`. To restore the old behaviour, set `*PROPAGATE-ERRORS*` to `NIL**.
+
+**NOTE:** `AL:GET-ERROR`/`AL:CLEAR-ERROR` are distinct from `ALUT:GET-ERROR`/`ALUT:CLEAR-ERROR`,
+because the error handling in ALUT differs from error handling in OpenAL/ALC. Similarly, the
+condition reported for OpenAL/ALC errors is `AL-ERROR`, whereas for ALUT it's `ALUT-ERROR`. In
+previous versions, these symbols were accidentally merged. Code relying on the old behaviour will
+need to be updated (or converted to use automatic error checking, see below).
+
+By default, cl-openal will call `alGetError()`/`alutGetError` after every C operation and signal any
+errors via the `AL-ERROR`/`ALUT-ERROR` conditions. The specific error code be retrieved via
+`(AL:ERRCODE CONDITION)`.
+
+Previous versions of cl-openal did not have any provision for automatic error detection, and only
+provided `GET-ERROR` as a very thin wrapper around `alGetError()`. This not only requires user code to
+do its own error check after every operation, which is tedious and error-prone, but makes some
+operations inherently unsafe, as certain wrappers perform foreign memory accesses immediately after
+calling the underlying OpenAL functions, without any opportunity for the user to check for errors
+and abort. This means memory corruption is highly likely in those instances. This issue has been
+fixed, and even if `*PROPAGATE-ERRORS*` is `NIL`, all wrappers exported by packages `AL`, `ALC` and
+`ALUT` will now abort if any underlying C operations signals an error. In this case, the wrapper
+function will return `NIL`.
+
+If for some reason you need to use one of the low-level bindings in the `%AL` or `%ALC` packages,
+the macro `AL:DEFUN-AL` should be use instead of regular `DEFUN`. It automates clearing the error
+state at the beginning of the function, and the checking at the end, and exposes a local macro
+called `CHECKPOINT`, which should be inserted after every low-level operation, if it's not the last
+operation in the function definition. It will also ensure that `*PROPAGATE-ERRORS*` is respected.
+
+If you need to interact with the low-level bindings in `%ALUT`, a similar macro called `DEFUN-ALUT`
+is provided. It also automates error clearing and handling, but because the ALUT error reporting is
+different, it's simpler to use: there's no need to call `(CHECKPOINT)`, all CFFI calls are checked
+automatically.
+
+Thread safety
+-------------
+
+Unfortunately, the OpenAL specification is incomplete when it comes to thread safety. Although
+OpenAL contexts are specified to be thread safe, and a single OpenAL operation is atomic, the
+specification does not specify enough details to allow safe sharing of contexts between multiple
+threads. In particular, error handling through `alGetError()` is inherently not thread-safe, and if
+multiple threads perform operations on a single context simultaneously, they will have no way to
+tell whose operation caused the error being reported.
+
+cl-openal on its part is also not thread-safe in its error handling. If `*PROPAGATE-ERRORS*` is
+`NIL`, the mechanism uses the value of a special variable to store and report errors. Because
+special variable bindings are not visible across threads, retrieving the last error *will* break if
+done from multiple threads.
+
+For these reasons, **multiple threads should never access a single OpenAL context at the same
+time. Doing so is inherently unsafe and cannot be done without introducing race conditions.**
+
 Support
 -------
 

--- a/al/packages.lisp
+++ b/al/packages.lisp
@@ -45,12 +45,16 @@
 
 (defpackage #:cl-openal
   (:use :cl)
+  (:import-from :alexandria :with-gensyms)
   (:nicknames :al)
   (:export
+   :*propagate-errors* :al-error :peek-error :get-error :propagate-error
    :load-libraries
-   :enable :disable :enabledp :get-string :get-boolean :get-integer :get-error :extension-present-p
+   :enable :disable :enabledp :get-string :get-boolean :get-integer :extension-present-p
    :get-proc-address :get-enum-value :listener :get-listener :gen-sources :gen-source :delete-sources
    :delete-source :sourcep :source :get-source :source-play :source-stop :source-rewind :source-pause
    :source-queue-buffers :source-unqueue-buffers :gen-buffers :gen-buffer :delete-buffers
    :delete-buffer :bufferp :buffer :get-buffer :doppler-factor :doppler-velocity :speed-of-sound
-   :distance-model :buffer-data :with-source :with-sources :with-buffer :with-buffers))
+   :distance-model :buffer-data
+   :defun-al :checkpoint
+   :with-source :with-sources :with-buffer :with-buffers))

--- a/alc/alc.lisp
+++ b/alc/alc.lisp
@@ -8,17 +8,18 @@
     (t (:default "libopenal")))
   (cffi:use-foreign-library al))
 
-(defun open-device (&optional device-name)
+(defun-al open-device (&optional device-name)
   (let ((foreign-dev (%alc:open-device (or device-name
                                            (cffi:null-pointer)))))
+    (checkpoint)
     (if (cffi:null-pointer-p foreign-dev)
         nil
         foreign-dev)))
 
-(defun close-device (device)
+(defun-al close-device (device)
   (%alc:close-device device))
 
-(defun create-context (device &rest attributes)
+(defun-al create-context (device &rest attributes)
   (let ((foreign-ctx
          (%alc:create-context device
                               (if attributes
@@ -29,59 +30,62 @@
                                                   (elt attributes i)))
                                       attrlist))
                                   (cffi:null-pointer)))))
+    (checkpoint)
     (if (cffi:null-pointer-p foreign-ctx)
         nil
         foreign-ctx)))
 
-(defun make-context-current (context)
+(defun-al make-context-current (context)
   (%alc:make-context-current context))
 
-(defun process-context (context)
+(defun-al process-context (context)
   (%alc:process-context context))
-(defun suspend-context (context)
+(defun-al suspend-context (context)
   (%alc:suspend-context context))
-(defun destroy-context (context)
+(defun-al destroy-context (context)
   (%alc:destroy-context context))
 
-(defun get-current-context ()
+(defun-al get-current-context ()
   (%alc:get-current-context))
-(defun get-contexts-device (context)
+(defun-al get-contexts-device (context)
   (%alc:get-contexts-device context))
 
-(defun get-error (device)
+(defun-al get-error (device)
   (%alc:get-error device))
 
-(defun extension-present-p (device extname)
+(defun-al extension-present-p (device extname)
   (%alc:is-extension-present device extname))
-(defun get-proc-address (funcname)
+(defun-al get-proc-address (funcname)
   (%alc:get-proc-address funcname))
 
-(defun get-enum-value (device enum-name)
+(defun-al get-enum-value (device enum-name)
   (%alc:get-enum-value device enum-name))
 
-(defun get-string (device param)
+(defun-al get-string (device param)
   (%alc:get-string device param))
-(defun get-integer (device param)
+(defun-al get-integer (device param)
   (cffi:with-foreign-object (size-arr :int 1)
     (%alc:get-integer-v device :attributes-size 1 size-arr)
+    (checkpoint)
     (let ((size (cffi:mem-aref size-arr :int 0)))
       (cffi:with-foreign-object (int-list :int size)
         (%alc:get-integer-v device param size int-list)
+        (checkpoint)
         (loop for i below size
            collect (cffi:mem-aref int-list :int i))))))
 
-(defun capture-open-device (device-name frequency format buffer-size)
+(defun-al capture-open-device (device-name frequency format buffer-size)
   (%alc:capture-open-device device-name
                             (coerce frequency 'integer)
                             format
                             (coerce buffer-size 'integer)))
-(defun capture-close-device (device)
+(defun-al capture-close-device (device)
   (%alc:capture-close-device device))
-(defun capture-start (device)
+(defun-al capture-start (device)
   (%alc:capture-start device))
-(defun capture-stop (device)
+(defun-al capture-stop (device)
   (%alc:capture-stop device))
-(defun capture-samples (device samples)
+(defun-al capture-samples (device samples)
   (let ((n-samples (length samples)))
     (cffi:with-foreign-object (buffer :pointer n-samples)
       (loop for i below n-samples

--- a/alc/packages.lisp
+++ b/alc/packages.lisp
@@ -20,6 +20,7 @@
 
 (defpackage #:cl-openal-alc
   (:use :cl)
+  (:import-from :al :defun-al :checkpoint)
   (:nicknames :alc)
   (:export
    #:load-libraries

--- a/alut/alut.lisp
+++ b/alut/alut.lisp
@@ -8,25 +8,58 @@
     (t (:default ("libalut"))))
   (cffi:use-foreign-library alut))
 
-(defun init ()
+;; NOTE: ALUT-ERROR is defined in %ALUT, but we re-export it
+
+(defvar *previous-error* nil
+  "Internal: if non-NIL, stores the error code recorded by ALUT-ERROR handler established
+  inside DEFUN-ALUT. In that case GET-ERROR will clear and return this value instead of
+  actually calling `alutGetError'. Only relevant when AL:*PROPAGATE-ERRORS* is NIL")
+
+(defmacro defun-alut (name (&rest args) &body body)
+  "Like DEFUN, but will automatically handle errors in any ALUT bindings being
+  called. This is different from DEFUN-AL, because ALUT error reporting is different from
+  OpenAL error reporting. Because (save for a handful of exceptions) ALUT functions always
+  report a boolean indicating whether an operation succeed, it's possible to make the
+  error handling entirely automatic.
+
+  BODY is executed inside a HANDLER-BIND, set up to handle ALUT-ERROR. If one is
+  signalled, and AL:*PROPAGATE-ERRORS* is set, the handler will simply decline to handle
+  it and let it propagate further. If it's NIL, the handler will record the code in
+  *PREVIOUS-ERROR*, so that GET-ERROR can return it to the user when called"
+  `(defun ,name (,@args)
+     (handler-bind
+         ((alut-error (lambda (err)
+                        (unless *propagate-errors*
+                          (setf *previous-error* (errcode err))
+                          (return-from ,name)))))
+       (clear-error)
+       ,@body)))
+
+(defun-alut init ()
   (%alut:init (cffi:null-pointer) (cffi:null-pointer)))
-(defun init-without-context ()
+(defun-alut init-without-context ()
   (%alut:init-without-context (cffi:null-pointer) (cffi:null-pointer)))
-(defun exit ()
+(defun-alut exit ()
   (%alut:exit))
 
-(defun get-error ()
+(defun clear-error ()
+  (setf *previous-error* nil)
   (%alut:get-error))
+(defun get-error ()
+  (if *previous-error*
+      (prog1 *previous-error*
+        (setf *previous-error* nil))
+      (%alut:get-error)))
 (defun get-error-string (error-name)
   (%alut:get-error-string error-name))
 
 ;;;
 ;;; Creating buffers
 ;;;
-(defun create-buffer-from-file (filename)
+(defun-alut create-buffer-from-file (filename)
   (%alut:create-buffer-from-file filename))
 
-(defun create-buffer-from-file-image (data)
+(defun-alut create-buffer-from-file-image (data)
   (let ((length (length data)))
     (cffi:with-foreign-object (data-array :int length)
       (loop for i below length
@@ -34,30 +67,26 @@
                   (elt data i)))
       (%alut:create-buffer-from-file-image data-array length))))
 
-(defun create-buffer-hello-world ()
+(defun-alut create-buffer-hello-world ()
   (%alut:create-buffer-hello-world))
 
-(defun create-buffer-waveform (waveshape frequency phase duration)
+(defun-alut create-buffer-waveform (waveshape frequency phase duration)
   (%alut:create-buffer-waveform waveshape frequency phase duration))
 
 ;;;
 ;;; Loading memory
 ;;;
-(defun load-memory-from-file (filename)
+(defun-alut load-memory-from-file (filename)
   (cffi:with-foreign-objects ((format '%al:enum)
                               (size :int)
                               (frequency '%al:ensure-float))
-    (values-list
-     (cons
-      (%alut:load-memory-from-file filename format size frequency)
-      (handler-case
-          (list (cffi:mem-ref format '%al:enum)
-                (cffi:mem-ref size :int)
-                (cffi:mem-ref frequency '%al:ensure-float))
-        (error ()
-          (error "There was an error loading ~A" filename)))))))
+    (values
+     (%alut:load-memory-from-file filename format size frequency)
+     (cffi:mem-ref format '%al:enum)
+     (cffi:mem-ref size :int)
+     (cffi:mem-ref frequency '%al:ensure-float))))
 
-(defun load-memory-from-file-image (data)
+(defun-alut load-memory-from-file-image (data)
   (let ((length (length data)))
     (cffi:with-foreign-objects ((format '%al:enum)
                                 (size :int)
@@ -66,50 +95,38 @@
       (loop for i below length
             do (setf (cffi:mem-aref data-array :int i)
                      (elt data i)))
-      (values-list
-       (cons
-        (%alut:load-memory-from-file-image data-array length format size
-                                           frequency)
-        (handler-case
-            (list (cffi:mem-ref format '%al:enum)
-                  (cffi:mem-ref size :int)
-                  (cffi:mem-ref frequency '%al::ensure-float))
-          (error ()
-            (error "There was an error loading data"))))))))
+      (values
+       (%alut:load-memory-from-file-image data-array length format size
+                                          frequency)
+       (cffi:mem-ref format '%al:enum)
+       (cffi:mem-ref size :int)
+       (cffi:mem-ref frequency '%al::ensure-float)))))
 
-(defun load-memory-hello-world ()
+(defun-alut load-memory-hello-world ()
   (cffi:with-foreign-objects ((format '%al:enum)
                               (size :int)
                               (frequency '%al:ensure-float))
-    (values-list
-     (cons
-      (%alut:load-memory-hello-world format size frequency)
-      (handler-case
-          (list (cffi:mem-ref format '%al:enum)
-                (cffi:mem-ref size :int)
-                (cffi:mem-ref frequency '%al::ensure-float))
-        (error ()
-          (error "There was an error loading memory!")))))))
+    (values
+     (%alut:load-memory-hello-world format size frequency)
+     (cffi:mem-ref format '%al:enum)
+     (cffi:mem-ref size :int)
+     (cffi:mem-ref frequency '%al::ensure-float))))
 
-(defun load-memory-waveform (waveshape frequency phase duration)
+(defun-alut load-memory-waveform (waveshape frequency phase duration)
   (cffi:with-foreign-objects ((format '%al:enum)
                               (size :int)
                               (freq '%al:ensure-float))
-    (values-list
-     (cons
-      (%alut:load-memory-waveform waveshape frequency phase duration format
-                                  size freq)
-      (handler-case
-          (list (cffi:mem-ref format '%al:enum)
-                (cffi:mem-ref size :int)
-                (cffi:mem-ref freq '%al::ensure-float))
-        (error ()
-          (error "There was an error loading this waveform")))))))
+    (values
+     (%alut:load-memory-waveform waveshape frequency phase duration format
+                                 size freq)
+     (cffi:mem-ref format '%al:enum)
+     (cffi:mem-ref size :int)
+     (cffi:mem-ref freq '%al::ensure-float))))
 
 ;;;
 ;;; Misc
 ;;;
-(defun get-mime-types (loader)
+(defun-alut get-mime-types (loader)
   (%alut:get-mime-types loader))
 
 (defun get-major-version ()
@@ -117,7 +134,7 @@
 (defun get-minor-version ()
   (%alut:get-minor-version))
 
-(defun sleep (duration)
+(defun-alut sleep (duration)
   (%alut:sleep duration))
 
 ;;;

--- a/alut/bindings.lisp
+++ b/alut/bindings.lisp
@@ -8,6 +8,62 @@
   (t (:default ("libalut"))))
 (use-foreign-library alut)
 
+;; Error handling, used by the rest of DEFCFUNs, so need to define it first
+
+(defcenum error
+  (:no-error 0)
+  (:out-of-memory #x200)
+  (:invalid-enum #x201)
+  (:invalid-value #x202)
+  (:invalid-operation #x203)
+  (:no-current-context #x204)
+  (:al-error-on-entry #x205)
+  (:alc-error-on-entry #x206)
+  (:open-device #x207)
+  (:close-device #x208)
+  (:create-context #x209)
+  (:make-context-current #x20A)
+  (:destroy-context #x20B)
+  (:gen-buffers #x20C)
+  (:buffer-data #x20D)
+  (:io-error #x20E)
+  (:unsupported-file-type #x20F)
+  (:unsupported-file-subtype #x210)
+  (:corrupt-or-truncated-data #x211))
+
+(defcfun ("alutGetError" get-error) error)
+(defcfun ("alutGetErrorString" get-error-string) :string (err error))
+
+(define-condition alut-error ()
+  ((%errcode :initarg :errcode :reader errcode))
+  (:report (lambda (c stream)
+             (format stream "ALUT error ~A" (errcode c)))))
+
+(defun validate-checked-value (value)
+  (let ((failed (or
+                 (not value)
+                 (and (pointerp value) (null-pointer-p value))
+                 (and (numberp value) (zerop value)))))
+    (if failed
+        (error 'alut-error :errcode (get-error))
+        value)))
+
+(defmacro define-checked-type (type)
+  (let ((name (intern (format nil "~A-~A" :checked type))))
+    `(progn
+       (define-foreign-type ,name ()
+         ()
+         (:actual-type ,type)
+         (:simple-parser ,name)
+         (:documentation ,(format nil "Check ~A indicating whether an operation succeeded" type)))
+       (defmethod translate-from-foreign (value (type ,name))
+         (validate-checked-value value)))))
+
+(define-checked-type :boolean)
+(define-checked-type :pointer)
+(define-checked-type :uint)
+(define-checked-type :string)
+
 (define-foreign-type ensure-integer ()
   ()
   (:actual-type :int)
@@ -51,27 +107,6 @@
   (:major-version 1)
   (:minor-version 1))
 
-(defcenum error
-  (:no-error 0)
-  (:out-of-memory #x200)
-  (:invalid-enum #x201)
-  (:invalid-value #x202)
-  (:invalid-operation #x203)
-  (:no-current-context #x204)
-  (:al-error-on-entry #x205)
-  (:alc-error-on-entry #x206)
-  (:open-device #x207)
-  (:close-device #x208)
-  (:create-context #x209)
-  (:make-context-current #x20A)
-  (:destroy-context #x20B)
-  (:gen-buffers #x20C)
-  (:buffer-data #x20D)
-  (:io-error #x20E)
-  (:unsupported-file-type #x20F)
-  (:unsupported-file-subtype #x210)
-  (:corrupt-or-truncated-data #x211))
-
 (defcenum waveform
   (:sine #x100)
   (:square #x101)
@@ -92,36 +127,33 @@
     `(with-foreign-string (,var (if (pathnamep ,value) (namestring ,value) ,value))
        ,@body)))
 
-(defcfun ("alutInit" init) :boolean (argcp :pointer) (argv :pointer))
-(defcfun ("alutInitWithoutContext" init-without-context) :boolean
+(defcfun ("alutInit" init) checked-boolean (argcp :pointer) (argv :pointer))
+(defcfun ("alutInitWithoutContext" init-without-context) checked-boolean
   (argcp :pointer) (argv :pointer))
-(defcfun ("alutExit" exit) :boolean)
+(defcfun ("alutExit" exit) checked-boolean)
 
-(defcfun ("alutGetError" get-error) error)
-(defcfun ("alutGetErrorString" get-error-string) :string (err error))
-
-(defcfun ("alutCreateBufferFromFile" create-buffer-from-file) :uint
+(defcfun ("alutCreateBufferFromFile" create-buffer-from-file) checked-uint
   (filename pathname-string))
-(defcfun ("alutCreateBufferFromFileImage" create-buffer-from-file-image) :uint
+(defcfun ("alutCreateBufferFromFileImage" create-buffer-from-file-image) checked-uint
   (data (:pointer :void)) (length :int))
-(defcfun ("alutCreateBufferHelloWorld" create-buffer-hello-world) :uint)
-(defcfun ("alutCreateBufferWaveform" create-buffer-waveform) :uint
+(defcfun ("alutCreateBufferHelloWorld" create-buffer-hello-world) checked-uint)
+(defcfun ("alutCreateBufferWaveform" create-buffer-waveform) checked-uint
   (waveshape waveform) (frequency ensure-float) (phase ensure-float) (duration ensure-float))
 
-(defcfun ("alutLoadMemoryFromFile" load-memory-from-file) :pointer
+(defcfun ("alutLoadMemoryFromFile" load-memory-from-file) checked-pointer
   (filename pathname-string) (format :pointer) (size :pointer) (frequency :pointer))
-(defcfun ("alutLoadMemoryFromFileImage" load-memory-from-file-image) :pointer
+(defcfun ("alutLoadMemoryFromFileImage" load-memory-from-file-image) checked-pointer
   (data (:pointer :void)) (length :int) (format :pointer) (size :pointer) (frequency :pointer))
-(defcfun ("alutLoadMemoryHelloWorld" load-memory-hello-world) :pointer
+(defcfun ("alutLoadMemoryHelloWorld" load-memory-hello-world) checked-pointer
   (format :pointer) (size :pointer) (frequency :pointer))
-(defcfun ("alutLoadMemoryWaveform" load-memory-waveform) :pointer
+(defcfun ("alutLoadMemoryWaveform" load-memory-waveform) checked-pointer
   (waveshape waveform) (frequency :float) (phase :float) (duration :float)
   (format :pointer) (size :pointer) (freq :pointer))
 
-(defcfun ("alutGetMIMETypes" get-mime-types) :string
+(defcfun ("alutGetMIMETypes" get-mime-types) checked-string
   (loader loader))
 
 (defcfun ("alutGetMajorVersion" get-major-version) :int)
 (defcfun ("alutGetMinorVersion" get-minor-version) :int)
 
-(defcfun ("alutSleep" sleep) :boolean (duration ensure-float))
+(defcfun ("alutSleep" sleep) checked-boolean (duration ensure-float))

--- a/alut/packages.lisp
+++ b/alut/packages.lisp
@@ -3,6 +3,8 @@
   (:nicknames :%alut)
   (:shadow :sleep)
   (:export
+   ;; error signalling
+   :alut-error
    ;; enums
    :api :error :waveform :loader
    ;; funcs
@@ -16,10 +18,12 @@
 
 (defpackage #:cl-openal-alut
   (:use :cl :al)
+  (:import-from :%alut :alut-error)
   (:nicknames :alut)
-  (:shadow :sleep)
+  (:shadow :sleep :get-error :clear-error)
   (:export
-   #:load-libraries
+   :alut-error
+   :load-libraries
    :init :init-without-context :exit :get-error :get-error-string :create-buffer-from-file
    :create-buffer-from-file-image :create-buffer-hello-world :create-buffer-waveform
    :load-memory-from-file :load-memory-from-file-image :load-memory-hello-world :load-memory-waveform

--- a/cl-openal.asd
+++ b/cl-openal.asd
@@ -4,7 +4,7 @@
   :maintainer "Kat Marchán <kzm@sykosomatic.org>"
   :author "Kat Marchán <kzm@sykosomatic.org>"
   :licence "public domain"
-  :depends-on (cffi)
+  :depends-on (cffi alexandria)
   :components
   ((:module al
             :components


### PR DESCRIPTION
Hey, this one is big, but I think it's pretty much necessary, since the error handling right now is more or less broken.

From the commit:

> This fixes two major issues with the way the bindings worked previously:
> 
> * All error-checking had to be done manually, like in C, but there was
>   nothing in the documentation to tell the user that it was needed
> * Several wrappers were inherently unsafe, because they accessed
>   foreign pointers immediately after calling a low-level binding, but
>   without checking for errors. This means even properly-written user
>   code that did check for errors could suffer memory corruption and
>   had no way of aborting these operations
> 
> The code now signals on any OpenAL error by default. This can be
> disabled by the user (for compatibility with old code which did not
> expect conditions to be signalled, and used GET-ERROR as it was
> supposed to). Even if automatic error propagation is disabled, any
> wrapper will abort if an error is detected.
> 
> Note that this mechanism is inherently not thread-safe, but then so is
> OpenAL error handling in general, so this is no worse.

Some additional notes to help your review:
* I tried to document everything in the `README`. Please have a look and see if that makes sense to you. It should also help you read the patch, since it explains the intent and expected usage
* `ALUT:GET-ERROR` was redefining `AL:GET-ERROR`. It doesn't seem to me that that was intentional, so I corrected that. Now that I think of it, this should probably also be documented as a breaking change in `README`
* I made the ALUT error handling conditionally non-signalling, just like in AL, but since many of the ALUT functions could signal even before, this might not be desirable actually. It would be simple enough to just make them signal always. We could also be fancy and make it so that the ones that would signal previously stay that way, whereas the rest becomes conditional, but that might be overkill. Since any existing code needs to be adapted to set `*PROPAGATE-ERRORS*` to `NIL` at the very least, it's probably not gonna be hard to fix while people are at it anyway. Let me know your thoughts
  * On that topic, I'm really not sure what your intention was with the old code. It caught `ERROR`s in places like `LOAD-MEMORY-FROM-FILE`, which CFFI does in fact usually signal in case of an ALUT failure, but that's only because the functions are defied not to touch the passed pointers if a failure occurs, so the foreign-memory reading code there tried to interpret unitialised memory as `ALenum`, which means the CFFI signalling an error was entirely accidental, and not exactly reliable
* You might notice that the error detection in ALUT is different, and entirely automatic, whereas the method used in AL sometimes requires a manual call to `(CHECKPOINT)`. I came up with the method used in ALUT later, when I realised they report errors differently and the macros would need to change, but it would be entirely possible to use the same approach to define dummy foreign "translators" in `%AL`, whose only job is to call `%AL:GET-ERROR` and signal if an error is detected. I could go either way, don't know what you prefer