### PR TITLE
Change ALUT cffi:define-foreign-library

### DIFF
--- a/alut/bindings.lisp
+++ b/alut/bindings.lisp
@@ -4,8 +4,8 @@
 (define-foreign-library alut
   (:windows "alut.dll" :calling-convention :stdcall)
   (:darwin (:or (:default "libalut") (:framework "alut")))
-  (:unix (:or "libalut.so" "libalut.so.0" "libalut.so.0.1.0"))
-  (t (:default ("libalut"))))
+  (:unix (:or "libalut.so.0.1.0" "libalut.so.0" "libalut.so"))
+  (t (:default "libalut")))
 (use-foreign-library alut)
 
 ;; Error handling, used by the rest of DEFCFUNs, so need to define it first


### PR DESCRIPTION
1) To not use a list on :default, seems like a typo.
2) Resort :unix bindings, from more to less specific. Same as the other bindings.

This is not just for consistency with other cffi:define-foreign-library declarations on this repo.

But I got into these 2 issues while using https://github.com/shinmera/deploy while making a bundle of my program which uses cl-openal and having the fix here seems to make more sense.